### PR TITLE
Renormalize LMNextToken.sample() probs to fix floating point errors

### DIFF
--- a/hfppl/distributions/lmcontext.py
+++ b/hfppl/distributions/lmcontext.py
@@ -27,6 +27,7 @@ class LMNextToken(Distribution):
 
     async def sample(self):
         probs = np.exp(self.ctx.next_token_logprobs)
+        probs /= np.sum(probs)  # Renormalize to fix floating point errors
         token_id = np.random.choice(len(probs), p=(probs))
         self.ctx.tokens.append(token_id)
         logprob = self.ctx.next_token_logprobs[token_id]


### PR DESCRIPTION
Due to numerical imprecision, the exponentiated `next_token_logprobs` occasionally do not sum to 1. When the discrepancy is too large, this causes `np.random.choice` to throw the following error:

```
    token_id = np.random.choice(len(probs), p=(probs))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "numpy/random/mtrand.pyx", line 975, in numpy.random.mtrand.RandomState.choice
ValueError: probabilities do not sum to 1
```

This is observed empirically when using token masking and appears to occur more frequently for smaller models (e.g., `llama-3.2-1B`).

This PR fixes this issue by renormalizing `next_token_logprobs` after exponentiation. This is intended as a stopgap fix pending future work to look into numerical stability in the token masking code.