### PR TITLE
Fix ValueError for `LMTokenMask.log_prob()` when the mask has no support

### DIFF
--- a/hfppl/distributions/lmcontext.py
+++ b/hfppl/distributions/lmcontext.py
@@ -78,6 +78,9 @@ class LMTokenMask(Distribution):
             if v
             else self.ctx.model_mask - self.mask
         )
+        if len(good_tokens) == 0:
+            # If there are no good tokens, the log probability of v under the mask is -inf
+            return float("-inf")
         bad_tokens = [i for i in self.ctx.model_mask if i not in good_tokens]
         logprob_good = logsumexp(self.ctx.next_token_logprobs[list(good_tokens)])
         self.ctx.next_token_logprobs[bad_tokens] = float("-inf")

--- a/hfppl/distributions/lmcontext.py
+++ b/hfppl/distributions/lmcontext.py
@@ -80,9 +80,11 @@ class LMTokenMask(Distribution):
         )
         if len(good_tokens) == 0:
             # If there are no good tokens, the log probability of v under the mask is -inf
-            return float("-inf")
+            logprob_good = float("-inf")
+        else:
+            logprob_good = logsumexp(self.ctx.next_token_logprobs[list(good_tokens)])
+
         bad_tokens = [i for i in self.ctx.model_mask if i not in good_tokens]
-        logprob_good = logsumexp(self.ctx.next_token_logprobs[list(good_tokens)])
         self.ctx.next_token_logprobs[bad_tokens] = float("-inf")
         self.ctx.next_token_logprobs -= logprob_good
         self.ctx.model_mask = good_tokens


### PR DESCRIPTION
There are various scenarios in which token masking results in a `LMTokenMask` distribution that has a null support. This can occur when a mask rules out all tokens in the vocab, or when multiple sequential observations of `mask_dist()` are mutually incompatible (i.e., their set intersection is empty).

Currently, this corner case is not well accounted for and results in a fairly cryptic `ValueError: zero-size array to reduction operation maximum which has no identity`: 

```
  File "hfppl/hfppl/modeling.py", line 222, in observe
    p = await dist.log_prob(x)
        ^^^^^^^^^^^^^^^^^^^^^^
  File "hfppl/hfppl/distributions/lmcontext.py", line 81, in log_prob
    logprob_good = logsumexp(self.ctx.next_token_logprobs[list(good_tokens)])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "hfppl/hfppl/util.py", line 7, in logsumexp
    m = np.max(nums)
        ^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/numpy/core/fromnumeric.py", line 2810, in max
    return _wrapreduction(a, np.maximum, 'max', axis, None, out,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.11/site-packages/numpy/core/fromnumeric.py", line 88, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: zero-size array to reduction operation maximum which has no identity
```

This PR proposes to address this issue by defining `LMTokenMask.log_prob(v) := -inf` when the mask has no support under `v` (i.e., there are no `good_tokens` for `v`). From a practical standpoint, this fix is useful for addressing the `zero-size array` error above. However, it is still possible to instantiate "degenerate" LMTokenMask distributions (we simply define their density to be 0 everywhere).

From a more theoretical standpoint, this issue is a bit tricky because `LMTokenMask` objects are closely intertwined with `LMContext.model_mask`. Other partial/complementary solutions include:
- Raising an error when `LMTokenMask` is instantiated with null support
- Monitoring `LMContext.model_mask` to ensure that it never becomes the empty set

@alex-lew let me know what you think, happy to discuss.