### PR TITLE
Add options for configuring quantization in CachedCausalLM.from_pretrained()

### DIFF
--- a/hfppl/llms.py
+++ b/hfppl/llms.py
@@ -216,7 +216,7 @@ class TokenTrie:
             token_logits = logits[j - base]
             token_logprobs = torch.log_softmax(token_logits, 0)
 
-            node = node.add_token(token_id, token_logprobs.cpu().numpy())
+            node = node.add_token(token_id, token_logprobs.float().cpu().numpy())
 
         return node
 
@@ -357,7 +357,7 @@ class CachedCausalLM:
         ).logits[0][0]
         logprobs = torch.log_softmax(logits, 0)
 
-        self.cache = TokenTrie(None, logprobs.cpu().numpy())
+        self.cache = TokenTrie(None, logprobs.float().cpu().numpy())
 
         # Cache vocabulary
         bos_len = len(self.tokenizer.decode([self.tokenizer.bos_token_id]))

--- a/hfppl/llms.py
+++ b/hfppl/llms.py
@@ -307,7 +307,7 @@ class CachedCausalLM:
             auth_token (str): a HuggingFace API key. Only necessary if using private models, e.g. Meta's Llama models, which require authorization.
             load_in_4bit (bool): whether to use the `bitsandbytes` library to load the model in 4-bit quantized form.
             load_in_8bit (bool): whether to use the `bitsandbytes` library to load the model in 8-bit quantized form.
-            torch_dtype (str): the PyTorch dtype to use for the model. Defaults to `torch.float32`.
+            torch_dtype (str): the PyTorch dtype to use for the model. Defaults to `auto`, which uses the default dtype for the model.
             bnb_config (BitsAndBytesConfig): a custom configuration for quantization. If specified, `load_in_4bit` and `load_in_8bit` are ignored.
 
         Returns:


### PR DESCRIPTION
Adds several kwargs to CachedCausalLM.from_pretrained() to make quantization more configurable. Preserves the default behavior of `load_in_8bit=True`.

Motivation: It turns out that NVIDIA Hopper removed int8 support (https://github.com/bitsandbytes-foundation/bitsandbytes/issues/599) in favor of float8 quantization. This is an issue for running hfppl on H100 GPUs which use Hopper architecture. More generally, with the space of LLMs and quantization schemes evolving quickly, the existing `CachedCausalLM.from_pretrained()` should offer the user more configuration control.

As a quick fix, this PR adds the ability to pass `load_in_4bit` as well as to specify a custom `bnb_config`. It's also separately useful to be able to pass a `torch_dtype`.

~~Future steps: Certain llama models now use `torch.bfloat16`; however, this dtype isn't supported by numpy so it's currently incompatible with `hfppl`, but there are multiple workarounds we should explore that extend numpy to support it.~~
EDIT: Turns out the only issue with `bfloat16` arises when we try to store logprobs in the Trie without converting them to a numpy-friendly format. I've added calls to `.float()` in 2 cases and these seem to be sufficient to support `bfloat16` models.