### PR TITLE
Raise a `NullMask()` error for degenerate token masks

### DIFF
--- a/hfppl/distributions/lmcontext.py
+++ b/hfppl/distributions/lmcontext.py
@@ -80,7 +80,8 @@ class LMTokenMask(Distribution):
         )
         if len(good_tokens) == 0:
             # If there are no good tokens, the log probability of v under the mask is -inf
-            # logprob_good = float("-inf")
+            # However, since this method updates the model_mask as a side-effect,
+            # this will put the context in an invalid state, so we instead raise an exception.
             raise NullMask("Unable to compute log probability of mask that rules out all tokens.")
         else:
             logprob_good = logsumexp(self.ctx.next_token_logprobs[list(good_tokens)])

--- a/hfppl/distributions/lmcontext.py
+++ b/hfppl/distributions/lmcontext.py
@@ -80,7 +80,8 @@ class LMTokenMask(Distribution):
         )
         if len(good_tokens) == 0:
             # If there are no good tokens, the log probability of v under the mask is -inf
-            logprob_good = float("-inf")
+            # logprob_good = float("-inf")
+            raise NullMask("Unable to compute log probability of mask that rules out all tokens.")
         else:
             logprob_good = logsumexp(self.ctx.next_token_logprobs[list(good_tokens)])
 
@@ -89,6 +90,10 @@ class LMTokenMask(Distribution):
         self.ctx.next_token_logprobs -= logprob_good
         self.ctx.model_mask = good_tokens
         return logprob_good
+
+
+class NullMask(Exception):
+    pass
 
 
 class LMContext:

--- a/hfppl/llms.py
+++ b/hfppl/llms.py
@@ -44,6 +44,7 @@ class Masks:
             for (i, v) in enumerate(lm.str_vocab)
             if any(c in string.whitespace for c in v)
         )
+        self.EOS = set([lm.tokenizer.eos_token_id])
 
         self.MAX_TOKEN_LENGTH = self.precompute_token_length_masks(lm)
 


### PR DESCRIPTION
As discussed in https://github.com/probcomp/hfppl/pull/21, there are various scenarios in which token masking results in a LMTokenMask distribution that has a null support. The previous PR partially solved this problem by returning `-inf`, which avoided a cryptic `ValueError` message. However, this still results in an uncaught downstream exception the next time `sample()` or `observe()` is called, making it hard to localize the source of the error when debugging.

On further reflection, a complete solution to this problem would be to implement tracing -- minimally, for mask objects, but ideally at the level of the `hfppl` itself -- to make it possible to track sequences of stochastic events leading to errors. I think this is a potentially useful approach but would require deeper refactors to the library than I have bandwidth for at the moment.

In the spirit of keeping things simple for now, I think it makes sense to introduce a `NullMask()` error that gets raised when observing a degenerate mask. This has the sole purpose of providing a more descriptive error and a clear stack trace for what I've found to be a common corner case in `hfppl` programs.