### PR TITLE
Add csmc_standard inference method

### DIFF
--- a/llamppl/inference/__init__.py
+++ b/llamppl/inference/__init__.py
@@ -5,7 +5,10 @@ This module currently provides the following inference methods:
 * `smc_standard(model, num_particles, ess_threshold=0.5)`: Standard SMC with multinomial resampling.
 
 * `smc_steer(model, num_beams, num_expansions)`: a without-replacement SMC algorithm that resembles beam search.
+
+* `csmc_standard(model, n_particles, ess_threshold=0.5)`: Conditional SMC (Andrieu, Doucet & Holenstein 2010) — a $\\pi$-invariant transition kernel on trajectories, suitable as the inner loop of an MCMC or Particle Gibbs sampler.
 """
 
+from .csmc_standard import csmc_standard
 from .smc_standard import smc_standard
 from .smc_steer import smc_steer

--- a/llamppl/inference/csmc_standard.py
+++ b/llamppl/inference/csmc_standard.py
@@ -1,0 +1,100 @@
+"""Conditional Sequential Monte Carlo (C-SMC).
+
+C-SMC (Andrieu, Doucet & Holenstein 2010, §4.3) is a variant of SMC in
+which slot 0 of the particle population is a *retained particle*: it is
+extended deterministically along a fixed pre-specified trajectory and
+exempt from resampling. The remaining ``n_particles - 1`` slots evolve
+as in standard SMC.
+
+The retained slot's deterministic extension is the responsibility of
+the supplied :class:`Model`'s ``step`` method, which is expected to
+branch on a writeable ``is_retained`` attribute that this loop sets and
+re-establishes after every resample.
+"""
+
+import asyncio
+import copy
+
+import numpy as np
+
+from ..util import logsumexp
+
+
+async def csmc_standard(model, n_particles, ess_threshold=0.5):
+    """Conditional sequential Monte Carlo with multinomial resampling.
+
+    Slot 0 is the retained particle: pinned across resampling rounds and
+    extended deterministically by the model whenever its ``is_retained``
+    attribute is ``True``. Slots 1..``n_particles - 1`` are free.
+
+    Args:
+        model (llamppl.Model): The particle model. Must expose a writeable
+            ``is_retained`` attribute; its ``step`` method is expected to
+            branch on this tag and force the next move when retained.
+        n_particles (int): Total number of particles, including the
+            retained one. Must be ``>= 1``; ``n_particles >= 2`` is
+            required for nontrivial mixing (Andrieu et al. 2010,
+            Theorem 5(b)).
+        ess_threshold (float): Fraction of ``n_particles`` below which
+            resampling is triggered.
+
+    Returns:
+        particles (list[llamppl.Model]): The completed particles. Slot 0
+            carries the retained-particle trajectory; the remaining
+            ``n_particles - 1`` carry trajectories that may have inherited
+            from any slot (including slot 0).
+
+    Notes:
+        Resampling is hardcoded to **multinomial**. The C-SMC invariance
+        proof (Andrieu, Doucet & Holenstein 2010, Assumption 2) relies on
+        unbiased multinomial draws for the free slots; stratified,
+        systematic, and residual resampling introduce dependence between
+        resampled indices that complicates the invariance argument and
+        is not supported here. Extending C-SMC to other resampling
+        schemes is possible but requires a separate derivation (see,
+        e.g., Chopin & Singh 2015, *On Particle Gibbs Sampling*) and is
+        out of scope for this implementation.
+    """
+    if n_particles < 1:
+        raise ValueError(f"n_particles must be >= 1, got {n_particles}")
+
+    # Retainedness is a slot property, not a particle property: slot 0 is
+    # always the retained slot, regardless of which trajectory any slot
+    # inherits via resampling.
+    particles = [copy.deepcopy(model) for _ in range(n_particles)]
+    particles[0].is_retained = True
+    for p in particles[1:]:
+        p.is_retained = False
+
+    while any(not p.done_stepping() for p in particles):
+        for p in particles:
+            p.untwist()
+        await asyncio.gather(
+            *[p.step() for p in particles if not p.done_stepping()]
+        )
+
+        W = np.array([p.weight for p in particles])
+        if np.all(W == -np.inf):
+            # All particles dead — skip resampling to avoid NaNs.
+            continue
+        w_sum = logsumexp(W)
+        normalized_log_weights = W - w_sum
+
+        ess_log = -logsumexp(2 * normalized_log_weights)
+        if ess_log < np.log(ess_threshold) + np.log(n_particles):
+            probs = np.exp(normalized_log_weights)
+            avg_weight = w_sum - np.log(n_particles)
+            # Slot 0 survives unchanged and stays retained; slots 1..N-1
+            # are drawn multinomially from all N weights and marked free.
+            particles[0].weight = avg_weight
+            particles[0].is_retained = True
+            new_particles = [particles[0]]
+            for _ in range(n_particles - 1):
+                idx = np.random.choice(n_particles, p=probs)
+                p = copy.deepcopy(particles[idx])
+                p.weight = avg_weight
+                p.is_retained = False
+                new_particles.append(p)
+            particles = new_particles
+
+    return particles

--- a/llamppl/inference/csmc_standard.py
+++ b/llamppl/inference/csmc_standard.py
@@ -66,12 +66,16 @@ async def csmc_standard(model, n_particles, ess_threshold=0.5):
     for p in particles[1:]:
         p.is_retained = False
 
+    # Run the model's start hook before stepping, exactly as smc_standard
+    # and smc_steer do. Subclasses use start() to establish the initial
+    # weight (e.g. the prefix weight of the empty sequence) and to validate
+    # the target; skipping it drops that contribution from every particle.
+    await asyncio.gather(*[p.start() for p in particles])
+
     while any(not p.done_stepping() for p in particles):
         for p in particles:
             p.untwist()
-        await asyncio.gather(
-            *[p.step() for p in particles if not p.done_stepping()]
-        )
+        await asyncio.gather(*[p.step() for p in particles if not p.done_stepping()])
 
         W = np.array([p.weight for p in particles])
         if np.all(W == -np.inf):

--- a/tests/test_csmc_standard.py
+++ b/tests/test_csmc_standard.py
@@ -14,9 +14,14 @@ from llamppl.inference import csmc_standard
 
 class _MockModel:
     """A duck-typed mock of the subset of ``llamppl.Model`` that
-    :func:`csmc_standard` actually touches: ``untwist``, ``step``,
-    ``done_stepping``, the writeable ``weight`` attribute, and the
-    ``is_retained`` tag the loop manipulates.
+    :func:`csmc_standard` actually touches: ``start``, ``untwist``,
+    ``step``, ``done_stepping``, the writeable ``weight`` attribute, and
+    the ``is_retained`` tag the loop manipulates.
+
+    ``start`` records that it ran (``start_calls``) and scores
+    ``start_weight`` onto the particle, mirroring how a real
+    :class:`llamppl.Model` (e.g. genlm-control's ``SequenceModel``) uses
+    its start hook to establish the initial weight before any step.
 
     ``step`` records whether the slot is retained at the time of the
     call and scores the weight differently for retained vs. free
@@ -24,14 +29,22 @@ class _MockModel:
     resampling on every round.
     """
 
-    def __init__(self, n_steps=3, score_retained=10.0, score_free=0.0):
+    def __init__(
+        self, n_steps=3, score_retained=10.0, score_free=0.0, start_weight=0.0
+    ):
         self.n_steps = n_steps
         self.step_idx = 0
         self.weight = 0.0
         self.slot_history = []  # list of "retained"/"free" per call to step
         self.is_retained = False
+        self.start_calls = 0  # number of times start() ran on this particle
         self._score_retained = score_retained
         self._score_free = score_free
+        self._start_weight = start_weight
+
+    async def start(self):
+        self.start_calls += 1
+        self.weight += self._start_weight
 
     def untwist(self):
         pass
@@ -41,9 +54,7 @@ class _MockModel:
 
     async def step(self):
         self.slot_history.append("retained" if self.is_retained else "free")
-        self.weight += (
-            self._score_retained if self.is_retained else self._score_free
-        )
+        self.weight += self._score_retained if self.is_retained else self._score_free
         self.step_idx += 1
 
 
@@ -51,9 +62,7 @@ def test_runs_to_termination():
     """Smoke test: with a model that finishes after ``n_steps`` calls,
     the loop terminates and returns ``n_particles`` particles."""
     model = _MockModel(n_steps=3)
-    particles = asyncio.run(
-        csmc_standard(model, n_particles=4, ess_threshold=0.5)
-    )
+    particles = asyncio.run(csmc_standard(model, n_particles=4, ess_threshold=0.5))
     assert len(particles) == 4
     for p in particles:
         assert p.done_stepping()
@@ -63,9 +72,7 @@ def test_slot_zero_history_all_retained():
     """Slot 0's recorded history is "retained" at every step, regardless
     of how many resamples happened in between."""
     model = _MockModel(n_steps=4)
-    particles = asyncio.run(
-        csmc_standard(model, n_particles=8, ess_threshold=1.0)
-    )
+    particles = asyncio.run(csmc_standard(model, n_particles=8, ess_threshold=1.0))
     assert particles[0].slot_history == ["retained"] * 4
 
 
@@ -82,9 +89,7 @@ def test_other_slots_free_at_termination():
     every resample.
     """
     model = _MockModel(n_steps=4)
-    particles = asyncio.run(
-        csmc_standard(model, n_particles=8, ess_threshold=1.0)
-    )
+    particles = asyncio.run(csmc_standard(model, n_particles=8, ess_threshold=1.0))
     for p in particles[1:]:
         assert p.is_retained is False
 
@@ -93,9 +98,7 @@ def test_n_particles_one():
     """M=1 degenerate case: only the retained slot exists, no
     resampling possible, all steps record "retained"."""
     model = _MockModel(n_steps=2)
-    particles = asyncio.run(
-        csmc_standard(model, n_particles=1, ess_threshold=0.5)
-    )
+    particles = asyncio.run(csmc_standard(model, n_particles=1, ess_threshold=0.5))
     assert len(particles) == 1
     assert particles[0].is_retained is True
     assert particles[0].slot_history == ["retained", "retained"]
@@ -113,9 +116,39 @@ def test_skips_resample_when_all_particles_dead():
     model = _MockModel(
         n_steps=2, score_retained=float("-inf"), score_free=float("-inf")
     )
-    particles = asyncio.run(
-        csmc_standard(model, n_particles=4, ess_threshold=1.0)
-    )
+    particles = asyncio.run(csmc_standard(model, n_particles=4, ess_threshold=1.0))
     assert len(particles) == 4
     for p in particles:
         assert p.done_stepping()
+
+
+def test_start_called_once_on_every_particle():
+    """Regression: ``csmc_standard`` must run the model's ``start`` hook
+    before stepping, exactly as ``smc_standard`` and ``smc_steer`` do.
+
+    Each returned particle (slot 0 and free slots, the latter possibly
+    deepcopied from a started particle during resampling) carries
+    ``start_calls == 1`` — start() ran once per particle, never zero and
+    never re-run after a resample.
+    """
+    model = _MockModel(n_steps=4)
+    particles = asyncio.run(csmc_standard(model, n_particles=8, ess_threshold=1.0))
+    for p in particles:
+        assert p.start_calls == 1
+
+
+def test_start_weight_contributes_to_output_weight():
+    """Regression: the start-weight a model scores in ``start`` must be
+    reflected in the particles' weights.
+
+    With uniform per-step scores the ESS stays maximal so no resampling
+    fires, and every particle's final weight is exactly ``start_weight``.
+    Before the fix (start() never called) this weight was 0.0.
+    """
+    start_weight = 7.0
+    model = _MockModel(
+        n_steps=3, score_retained=0.0, score_free=0.0, start_weight=start_weight
+    )
+    particles = asyncio.run(csmc_standard(model, n_particles=4, ess_threshold=0.5))
+    for p in particles:
+        assert p.weight == start_weight

--- a/tests/test_csmc_standard.py
+++ b/tests/test_csmc_standard.py
@@ -1,0 +1,121 @@
+"""Tests for :func:`llamppl.inference.csmc_standard`.
+
+These tests exercise the C-SMC contract: slot 0 of the particle
+population is retained across resampling rounds and the ``is_retained``
+tag is a slot property re-established after every resample.
+"""
+
+import asyncio
+
+import pytest
+
+from llamppl.inference import csmc_standard
+
+
+class _MockModel:
+    """A duck-typed mock of the subset of ``llamppl.Model`` that
+    :func:`csmc_standard` actually touches: ``untwist``, ``step``,
+    ``done_stepping``, the writeable ``weight`` attribute, and the
+    ``is_retained`` tag the loop manipulates.
+
+    ``step`` records whether the slot is retained at the time of the
+    call and scores the weight differently for retained vs. free
+    particles, so that weights diverge enough for the ESS check to fire
+    resampling on every round.
+    """
+
+    def __init__(self, n_steps=3, score_retained=10.0, score_free=0.0):
+        self.n_steps = n_steps
+        self.step_idx = 0
+        self.weight = 0.0
+        self.slot_history = []  # list of "retained"/"free" per call to step
+        self.is_retained = False
+        self._score_retained = score_retained
+        self._score_free = score_free
+
+    def untwist(self):
+        pass
+
+    def done_stepping(self):
+        return self.step_idx >= self.n_steps
+
+    async def step(self):
+        self.slot_history.append("retained" if self.is_retained else "free")
+        self.weight += (
+            self._score_retained if self.is_retained else self._score_free
+        )
+        self.step_idx += 1
+
+
+def test_runs_to_termination():
+    """Smoke test: with a model that finishes after ``n_steps`` calls,
+    the loop terminates and returns ``n_particles`` particles."""
+    model = _MockModel(n_steps=3)
+    particles = asyncio.run(
+        csmc_standard(model, n_particles=4, ess_threshold=0.5)
+    )
+    assert len(particles) == 4
+    for p in particles:
+        assert p.done_stepping()
+
+
+def test_slot_zero_history_all_retained():
+    """Slot 0's recorded history is "retained" at every step, regardless
+    of how many resamples happened in between."""
+    model = _MockModel(n_steps=4)
+    particles = asyncio.run(
+        csmc_standard(model, n_particles=8, ess_threshold=1.0)
+    )
+    assert particles[0].slot_history == ["retained"] * 4
+
+
+def test_other_slots_free_at_termination():
+    """Non-zero slots have ``is_retained == False`` at termination.
+
+    Note: we do *not* assert anything about ``slot_history`` of non-zero
+    slots, because the loop's post-last-step resample (after the final
+    step but before the while-check exits) may overwrite their
+    ``slot_history`` with deepcopied content from slot 0. The invariant
+    that survives that final inheritance is on the ``is_retained`` tag
+    itself, which the resample block re-establishes (slot 0 stays
+    retained, slots 1..N-1 are explicitly marked free) immediately after
+    every resample.
+    """
+    model = _MockModel(n_steps=4)
+    particles = asyncio.run(
+        csmc_standard(model, n_particles=8, ess_threshold=1.0)
+    )
+    for p in particles[1:]:
+        assert p.is_retained is False
+
+
+def test_n_particles_one():
+    """M=1 degenerate case: only the retained slot exists, no
+    resampling possible, all steps record "retained"."""
+    model = _MockModel(n_steps=2)
+    particles = asyncio.run(
+        csmc_standard(model, n_particles=1, ess_threshold=0.5)
+    )
+    assert len(particles) == 1
+    assert particles[0].is_retained is True
+    assert particles[0].slot_history == ["retained", "retained"]
+
+
+def test_n_particles_zero_raises():
+    with pytest.raises(ValueError, match="n_particles must be >= 1"):
+        asyncio.run(csmc_standard(_MockModel(), n_particles=0))
+
+
+def test_skips_resample_when_all_particles_dead():
+    """If every particle's weight is -inf, the resample block must skip
+    rather than feed NaN into ``np.random.choice``. Mirrors the same
+    guard in ``smc_standard``."""
+    model = _MockModel(
+        n_steps=2, score_retained=float("-inf"), score_free=float("-inf")
+    )
+    particles = asyncio.run(
+        csmc_standard(model, n_particles=4, ess_threshold=1.0)
+    )
+    assert len(particles) == 4
+    for p in particles:
+        assert p.done_stepping()


### PR DESCRIPTION
Conditional SMC (Andrieu, Doucet & Holenstein 2010, §4.3): an SMC sweep in which slot 0 is a retained particle, extended deterministically by the model and exempt from resampling, while the remaining N-1 slots evolve normally. When generation halts, a new memory is sampled.