### PR TITLE
ci: GPU tests opt-out + non-blocking (skip-gpu-tests label, gpu-gate, queue watchdog)

### DIFF
--- a/.github/workflows/gpu-queue-watchdog.yml
+++ b/.github/workflows/gpu-queue-watchdog.yml
@@ -1,0 +1,42 @@
+name: GPU queue watchdog
+
+# Cancels GPU runs stuck in the "queued" state past a threshold, so a PR
+# whose GPU jobs can't be scheduled fails fast (and its gpu-gate goes red)
+# instead of sitting queued for GitHub's 24h maximum.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  cancel-stale-queued:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      WORKFLOW: tests.yml
+      MAX_QUEUED_MIN: 20
+    steps:
+      - name: Cancel GPU runs stuck queued past threshold
+        run: |
+          set -euo pipefail
+          now=$(date -u +%s)
+          # Capture first so a gh/API failure fails the step (red) instead of silently no-op'ing.
+          queued=$(gh run list -R "$GITHUB_REPOSITORY" --workflow="$WORKFLOW" \
+            --status queued --json databaseId,createdAt -L 50)
+          echo "$queued" | jq -c '.[]' | while IFS= read -r row; do
+            id=$(echo "$row" | jq -r '.databaseId')
+            created=$(echo "$row" | jq -r '.createdAt')
+            # GNU date only (ubuntu-latest); use 'date -j -f' on macOS runners.
+            created_s=$(date -u -d "$created" +%s)
+            age_min=$(( (now - created_s) / 60 ))
+            if [ "$age_min" -ge "$MAX_QUEUED_MIN" ]; then
+              echo "Cancelling run $id (queued ${age_min}m >= ${MAX_QUEUED_MIN}m)"
+              gh run cancel "$id" -R "$GITHUB_REPOSITORY" || true
+            else
+              echo "Run $id queued ${age_min}m (< ${MAX_QUEUED_MIN}m) — leaving"
+            fi
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,17 +3,26 @@
 name: Codebase tests
 
 on:
+  workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main
+
+concurrency:
+  group: gpu-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   build:
-    runs-on: ParallelHoss
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-gpu-tests') }}
+    runs-on:
+      group: gpu-runners
+    timeout-minutes: 60
 
     steps:
       - name: Check out repository
@@ -74,3 +83,22 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.json
           slug: genlm/llamppl
+
+  gpu-gate:
+    # The single required status check for GPU tests.
+    # Passes when the GPU job succeeds OR is intentionally skipped
+    # (skip-gpu-tests label, or non-PR paths); fails on failure/cancelled.
+    if: ${{ always() }}
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require GPU job to pass or be intentionally skipped
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          echo "build=$BUILD_RESULT"
+          case "$BUILD_RESULT" in
+            success|skipped) ;;
+            *) echo "::error::GPU job result '$BUILD_RESULT'. Re-run, or apply the 'skip-gpu-tests' label to merge without GPU CI."; exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary
- The GPU `build` job now runs **by default** but can be skipped by a maintainer applying a **`skip-gpu-tests`** label. External/fork PRs can't apply labels, so GPU stays required for them.
- New **`gpu-gate`** job aggregates the GPU result (passes on `success`/`skipped`, fails on `failure`/`cancelled`). It is intended to become the **single required status check** for GPU, replacing the raw `build` job name — so a skipped or dead GPU run no longer leaves a `cancelled` check blocking merges.
- The GPU `build` job now targets the **`gpu-runners`** group (failover across `ParallelHoss` + `ParallelHoss2`); added `timeout-minutes: 60` and `concurrency: cancel-in-progress`.
- New scheduled **`gpu-queue-watchdog`** cancels runs stuck in `queued` > 20 min so PRs fail fast instead of hitting GitHub's 24h queue timeout.

**Background:** GPU runs had been auto-cancelled at the 24h queue cap (runner not accepting jobs), blocking PRs.

## Required follow-up after merge (maintainer / org admin)
- [ ] Branch protection → required status checks: add **`gpu-gate`**, remove `build`.
- [ ] Create the **`skip-gpu-tests`** label.
- [ ] Settings → Actions → General → **"Require approval for all external contributors"**.
- [ ] Confirm a real GPU run now completes on the `gpu-runners` group.

## Test plan
- [ ] On this PR, the `build` job starts on a `gpu-runners` runner (not stuck `queued`).
- [ ] Apply `skip-gpu-tests` → `build` shows `skipped`, `gpu-gate` is green, PR mergeable.
- [ ] Manually dispatch `gpu-queue-watchdog` once → runs clean.

_Note: `test_mlx` (macOS) is unchanged._