### PR TITLE
fix: an impossible mask kills the particle (weight 0) instead of aborting the SMC run

### DIFF
--- a/llamppl/distributions/lmcontext.py
+++ b/llamppl/distributions/lmcontext.py
@@ -78,12 +78,14 @@ class LMTokenMask(Distribution):
             else self.ctx.model_mask - self.mask
         )
         if len(good_tokens) == 0:
-            # If there are no good tokens, the log probability of v under the mask is -inf
-            # However, since this method updates the model_mask as a side-effect,
-            # this will put the context in an invalid state, so we instead raise an exception.
-            raise NullMask(
-                "Unable to compute log probability of mask that rules out all tokens."
-            )
+            # No token satisfies the mask: conditioning on it is a zero-probability
+            # event, so the log-probability is -inf. Return it *before* the
+            # model_mask / next_token_logprobs updates below — applying those with an
+            # empty good_tokens set would corrupt the context (NaN logprobs, empty
+            # mask). Model.observe finishes the particle when it sees this -inf, so
+            # the impossible particle is dropped at the next resample instead of
+            # being extended or aborting the run.
+            return float("-inf")
         else:
             logprob_good = logsumexp(self.ctx.next_token_logprobs[list(good_tokens)])
 
@@ -92,10 +94,6 @@ class LMTokenMask(Distribution):
         self.ctx.next_token_logprobs -= logprob_good
         self.ctx.model_mask = good_tokens
         return logprob_good
-
-
-class NullMask(Exception):
-    pass
 
 
 class LMContext:

--- a/llamppl/modeling.py
+++ b/llamppl/modeling.py
@@ -220,6 +220,11 @@ class Model:
         """
         p = await dist.log_prob(x)
         self.score(p)
+        if p == float("-inf"):
+            # A zero-probability observation makes this particle impossible;
+            # finish it (as condition(False) does) so it is dropped at the next
+            # resample rather than extended further.
+            self.finish()
         return x
 
     async def sample(self, dist, proposal=None):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -57,10 +57,10 @@ def test_haiku(LLM, n_particles=20):
     reason="hf-only regression; the MLX/macOS CI job runs hf on MPS and OOMs",
 )
 def test_haiku_impossible_mask_completes_instead_of_raising():
-    # Regression for #47: with this seed the haiku example drives a particle into
-    # an impossible mask (every token ruled out). That particle must be dropped
-    # (weight 0), not raise and abort the whole run. Deterministic on gpt2/hf
-    # because all sampling goes through the global numpy RNG.
+    # With this seed the haiku example drives a particle into an impossible mask
+    # (every token ruled out). That particle must be dropped (weight 0), not raise
+    # and abort the whole run. Deterministic on gpt2/hf because all sampling goes
+    # through the global numpy RNG.
     np.random.seed(21)
     LLM = CachedCausalLM.from_pretrained("gpt2", backend="hf")
     particles = asyncio.run(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -44,18 +44,7 @@ def test_hard_constraints(LLM, n_particles=20, max_tokens=25):
 
 
 @pytest.mark.parametrize("backend", backends)
-def test_haiku(LLM, backend, request, n_particles=20):
-    if backend == "vllm":
-        # Known failure under the vLLM backend: the haiku example hits
-        # NullMask ("Unable to compute log probability of mask that rules out
-        # all tokens"). Tracked separately for triage; xfail (non-strict) so it
-        # doesn't block CI but flags via xpass if it starts passing.
-        request.applymarker(
-            pytest.mark.xfail(
-                reason="vLLM backend: NullMask (mask rules out all tokens) in haiku example",
-                strict=False,
-            )
-        )
+def test_haiku(LLM, n_particles=20):
     particles = asyncio.run(
         run_haiku(LLM, poem_title="The beauty of testing", n_particles=n_particles)
     )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -52,6 +52,10 @@ def test_haiku(LLM, n_particles=20):
     assert len(particles) == n_particles
 
 
+@pytest.mark.skipif(
+    MLX_AVAILABLE,
+    reason="hf-only regression; the MLX/macOS CI job runs hf on MPS and OOMs",
+)
 def test_haiku_impossible_mask_completes_instead_of_raising():
     # Regression for #47: with this seed the haiku example drives a particle into
     # an impossible mask (every token ruled out). That particle must be dropped

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import numpy as np
 import pytest
 import torch
 
@@ -49,3 +50,16 @@ def test_haiku(LLM, n_particles=20):
         run_haiku(LLM, poem_title="The beauty of testing", n_particles=n_particles)
     )
     assert len(particles) == n_particles
+
+
+def test_haiku_impossible_mask_completes_instead_of_raising():
+    # Regression for #47: with this seed the haiku example drives a particle into
+    # an impossible mask (every token ruled out). That particle must be dropped
+    # (weight 0), not raise and abort the whole run. Deterministic on gpt2/hf
+    # because all sampling goes through the global numpy RNG.
+    np.random.seed(21)
+    LLM = CachedCausalLM.from_pretrained("gpt2", backend="hf")
+    particles = asyncio.run(
+        run_haiku(LLM, poem_title="The beauty of testing", n_particles=20)
+    )
+    assert len(particles) == 20

--- a/tests/test_lmcontext.py
+++ b/tests/test_lmcontext.py
@@ -66,11 +66,11 @@ def test_init(lm):
 
 
 def test_observe_impossible_mask_kills_particle():
-    # Regression for #47: conditioning on a mask that rules out every token is a
-    # zero-probability event. LMTokenMask.log_prob must return -inf (not raise),
-    # and Model.observe must finish the particle (weight 0) so it is dropped at the
-    # next resample instead of aborting the whole run. Backend-independent, so a
-    # fast mock LM with a hand-set, disjoint mask exercises the path deterministically.
+    # Conditioning on a mask that rules out every token is a zero-probability event.
+    # LMTokenMask.log_prob must return -inf (not raise), and Model.observe must
+    # finish the particle (weight 0) so it is dropped at the next resample instead of
+    # aborting the whole run. Backend-independent, so a fast mock LM with a hand-set,
+    # disjoint mask exercises the path deterministically.
     lm = CachedCausalLM.from_pretrained("gpt2", backend="mock")
     ctx = LMContext(lm, "Hello, world!")
     ctx.model_mask = {0, 1, 2}

--- a/tests/test_lmcontext.py
+++ b/tests/test_lmcontext.py
@@ -6,6 +6,7 @@ import torch
 
 from llamppl.distributions.lmcontext import LMContext
 from llamppl.llms import CachedCausalLM, MLX_AVAILABLE
+from llamppl.modeling import Model
 
 if MLX_AVAILABLE:
     backends = ["mock", "mlx"]
@@ -62,3 +63,23 @@ def test_init(lm):
         rtol=5e-4,
         err_msg="Async context create",
     )
+
+
+def test_observe_impossible_mask_kills_particle():
+    # Regression for #47: conditioning on a mask that rules out every token is a
+    # zero-probability event. LMTokenMask.log_prob must return -inf (not raise),
+    # and Model.observe must finish the particle (weight 0) so it is dropped at the
+    # next resample instead of aborting the whole run. Backend-independent, so a
+    # fast mock LM with a hand-set, disjoint mask exercises the path deterministically.
+    lm = CachedCausalLM.from_pretrained("gpt2", backend="mock")
+    ctx = LMContext(lm, "Hello, world!")
+    ctx.model_mask = {0, 1, 2}
+    impossible = ctx.mask_dist({3, 4})  # disjoint from model_mask: no good tokens
+
+    m = Model()
+    result = asyncio.run(m.observe(impossible, True))
+
+    assert result is True
+    assert m.weight == float("-inf")  # zero-probability observation -> weight 0
+    assert m.finished  # ...and the particle is finished
+    assert ctx.model_mask == {0, 1, 2}  # context untouched (returned before mutating)


### PR DESCRIPTION
## Problem
When a model conditions on a token mask that rules out every token (a zero-probability event), `LMTokenMask.log_prob` raised `NullMask`. Nothing catches it, so a single impossible particle aborted the entire SMC run. (The uncaught unwind could also leave a reused `LLM`'s autobatch state corrupted, surfacing later as `asyncio.InvalidStateError`.)

## Fix
Handle it the way `condition(False)` is already handled:
1. `LMTokenMask.log_prob` returns `-inf` (the correct log-probability of a zero-probability observation) instead of raising. It returns before the `model_mask` / `next_token_logprobs` updates, because applying those with an empty token set is what corrupts the context (and is what the pre-existing `-inf` code path fell through into).
2. `Model.observe` finishes the particle when an observation's log-probability is `-inf`, exactly as `condition(False)` does (`score(-inf)` then `finish()`). The impossible particle becomes weight 0 and done, and is dropped at the next resample.

Because the handling lives in `observe` and `log_prob`, it applies to every inference driver (`smc_standard`, `smc_steer`, and so on) with no per-driver changes and no new exception type. The now-unused `NullMask` exception is removed.

Closes #47.

## Deterministic reproduction
The failure is stochastic in normal use, but all sampling goes through the global numpy RNG, so seeding makes it deterministic. Save this as `repro.py` in the repo root and run it with `PYTHONPATH=. python repro.py` (needs the `hf` extra and downloads gpt2 on first run):

```python
import asyncio
import numpy as np
from llamppl import CachedCausalLM
from examples.haiku import run_example

np.random.seed(21)
LLM = CachedCausalLM.from_pretrained("gpt2", backend="hf")  # vLLM reproduces it too
asyncio.run(run_example(LLM, poem_title="The beauty of testing", n_particles=20))
```

On `main` this raises `NullMask: Unable to compute log probability of mask that rules out all tokens` and aborts the run. With this change it completes (the impossible particle is dropped at the next resample). Seeds 0 through 20 pass; seed 21 is the first that hits the dead-end.

## Test plan
Locally (hf, mock backends): `test_haiku` passes. Deterministic seed-21 completes instead of raising. GPU job on this PR checks to confirm the fix addresses what previously failed on vllm.